### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,7 +135,7 @@ curl -s -H "Cache-Control: no-cache" -o "stop.sh" "https://raw.githubusercontent
 # Download latest start script
 curl -s -H "Cache-Control: no-cache" -o "start.sh" "https://raw.githubusercontent.com/kus/cs2-modded-server/${BRANCH}/start.sh" && chmod +x start.sh
 
-PUBLIC_IP=$(dig +short myip.opendns.com @resolver1.opendns.com)
+PUBLIC_IP=$(dig -4 +short myip.opendns.com @resolver1.opendns.com)
 
 if [ -z "$PUBLIC_IP" ]; then
 	echo "ERROR: Cannot retrieve your public IP address..."


### PR DESCRIPTION
Assign the result of querying the DNS for the public IP address using the 'dig' command to the variable PUBLIC_IP PUBLIC_IP=$(dig -4 +short myip.opendns.com @resolver1.opendns.com)

By adding the '-4' flag to the 'dig' command, it specifies that the query should retrieve IPv4 addresses explicitly # This ensures that the 'dig' command retrieves the IPv4 address by default