### PR TITLE
Enable the buy menu for retakes

### DIFF
--- a/game/csgo/cfg/cs2-retakes/retakes.cfg
+++ b/game/csgo/cfg/cs2-retakes/retakes.cfg
@@ -37,4 +37,11 @@ mp_death_drop_defuser 1
 mp_death_drop_grenade 1
 mp_warmuptime 15
 
+// To enable buy menu
+mp_buy_anywhere 1
+mp_buytime 10 // Seconds to give players to buy after the round starts
+mp_maxmoney 65535
+mp_startmoney 65535
+mp_afterroundmoney 65535
+
 echo [Retakes] Config loaded!


### PR DESCRIPTION
Configured as per https://github.com/yonilerner/cs2-retakes-allocator

I figured this would be a valuable default since the retake allocator is already implemented.
I've received significant feedback that this menu is a lot more intuitive and faster to use than the !guns followed by deciding for each round type, the buy menu also opens for players to more easily switch between weapons after reach round