### PR TITLE
easiest way to fix install_docker

### DIFF
--- a/install_docker.sh
+++ b/install_docker.sh
@@ -133,10 +133,10 @@ echo "/home/user !!!!!!!"
 # mkdir -p /root/.steam/sdk64/
 # ln -sf /steamcmd/linux64/steamclient.so /root/.steam/sdk64/
 
-# mkdir -p /home/${user}/.steam/sdk32/
-# ln -sf /steamcmd/linux32/steamclient.so /home/${user}/.steam/sdk32/
-# mkdir -p /home/${user}/.steam/sdk64/
-# ln -sf /steamcmd/linux64/steamclient.so /home/${user}/.steam/sdk64/
+mkdir -p /home/${user}/.steam/sdk32/
+ln -sf /steamcmd/linux32/steamclient.so /home/${user}/.steam/sdk32/
+mkdir -p /home/${user}/.steam/sdk64/
+ln -sf /steamcmd/linux64/steamclient.so /home/${user}/.steam/sdk64/
 
 echo "Installing mods"
 cp -R /home/game/csgo/ /home/${user}/cs2/game/


### PR DESCRIPTION
Looks like nobody have tested `install_docker` last year.
the correct way to run it in docker (from `steam` account) is to uncomment this  part