### PR TITLE
feat: add aim_long_dust to aim mode

### DIFF
--- a/game/csgo/gamemodes_server.txt
+++ b/game/csgo/gamemodes_server.txt
@@ -419,6 +419,7 @@
 				"workshop/3078701726/aim_ak-colt_CS2"   ""
 				"workshop/3085962528/aim_usp"		""
 				"workshop/3075996446/aim_deagle"		""
+				"workshop/3082605693/aim_long_dust"		""
 			}
 		}
 		"mg_prefire"


### PR DESCRIPTION
I just tried this map on aim mode and looks like a great addition to the standard pool: https://steamcommunity.com/sharedfiles/filedetails/?id=3082605693&searchtext=aim

Surprisingly the workshop id was already on `subscribed_file_ids.txt`