### PR TITLE
Fix prefire plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .env copy
 /custom_files/*
 cs2
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,15 @@ ENV SRC_DIR="/home/cs2-modded-server"
 
 WORKDIR $SRC_DIR
 
-COPY . $SRC_DIR
+COPY custom_files $SRC_DIR/custom_files
+
+COPY install_docker.sh \
+    run.sh \
+    start.sh \
+    stop.sh \
+    $SRC_DIR
+
+COPY game/csgo $SRC_DIR/game/csgo
 
 USER steam
 


### PR DESCRIPTION
When i was looking into the issue with open prac i made a few changes
* bump to 1.44 prefire plugin to fix bug
* copy less files in docker
* updated the version checker script to also download the new versions to a tmp dir to assist with updating in the future, i didnt push in the updates as i noticed when i updated css the source had version 8 dot net but the repo has dotnet 7? but replacing reduce the size from 600mb to 80mb not sure why its like that but i assume there's a reason?


We could probably adjust the script to also auto update the addons and create a pr if you wanted? but figured id push these changes up

fixes #168 