### PR TITLE
- UPDATED: Download SteamCMD automatically if it is missing on Windows platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,9 @@ If you have git installed; it is recommended to use git and clone the repo `git 
 
 All the following instructions will use the repo folder location as the root.
 
-Create a folder `steamcmd` and [download SteamCMD](https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip) and extract it inside `steamcmd` so you should have `\steamcmd\steamcmd.exe`.
+~~Create a folder `steamcmd` and [download SteamCMD](https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip) and extract it inside `steamcmd` so you should have `\steamcmd\steamcmd.exe`.~~
+
+* Manual download of SteamCMD is no longer necessary as the startup script will handle it for you now.
 
 To download maps from the workshop, your server [needs access](https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive/Dedicated_Servers#Steam_Workshop) to the Steam Web API. To allow this, open `\win.ini` and set `cs_api_key` to your [Steam Web API Key](http://steamcommunity.com/dev/apikey).
 

--- a/win.bat
+++ b/win.bat
@@ -19,8 +19,11 @@ echo If you want to quit, close the CS2 window and type Y followed by Enter.
 
 :: Ensure steamcmd exists
 if not exist "%ROOT_DIR%steamcmd\steamcmd.exe" (
-    echo steamcmd\steamcmd.exe does not exist!
-    goto end
+    mkdir "%ROOT_DIR%steamcmd"
+    echo Downloading SteamCMD
+    powershell -Command "Invoke-WebRequest -Uri https://steamcdn-a.akamaihd.net/client/installer/steamcmd.zip -OutFile '%ROOT_DIR%steamcmd\steamcmd.zip'"
+    powershell -Command "Expand-Archive -Path '%ROOT_DIR%steamcmd\steamcmd.zip' -DestinationPath '%ROOT_DIR%steamcmd'"
+    del "%ROOT_DIR%steamcmd\steamcmd.zip"
 )
 
 :: Use SteamCMD to download CS2


### PR DESCRIPTION
So Windows users will no longer need to download SteamCMD manually for their first time on running the server pack.