### PR TITLE
Fix/copy command overwrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:bullseye-20240211-slim
 
 USER root
 
+# Run an apt update and add package dependencies
 RUN apt-get update --fix-missing \
     && apt-get install -y --no-install-recommends \
     sudo \
@@ -29,6 +30,7 @@ ENV STEAM_ACCOUNT=""
 RUN echo "steam ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/steam \
     && chmod 0440 /etc/sudoers.d/steam
 
+# $Home for the installation of cs2
 ENV HOME="/home/steam/cs2/"
 
 RUN mkdir -p $HOME && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - cs2-volume:/home/steam/
       - type: bind
         source: ./custom_files
-        target: /home/custom_files/
+        target: /home/cs2-modded-server/custom_files/
       - type: bind
         source: ./game
         target: /home/game/

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -141,7 +141,10 @@ echo "Installing mods"
 cp -R /home/cs2-modded-server/game/csgo/ /home/${user}/cs2/game/
 
 echo "Merging in custom files"
-cp -R /home/cs2-modded-server/custom_files/* /home/${user}/cs2/game/csgo/
+cp -Rf /home/cs2-modded-server/custom_files/* /home/${user}/cs2/game/csgo/
+
+echo "Current CSS admins.json File:"
+cat /home/${user}/cs2/game/csgo/addons/counterstrikesharp/configs/admins.json
 
 chown -R ${user}:${user} /home/${user}
 

--- a/install_docker.sh
+++ b/install_docker.sh
@@ -141,7 +141,7 @@ echo "Installing mods"
 cp -R /home/cs2-modded-server/game/csgo/ /home/${user}/cs2/game/
 
 echo "Merging in custom files"
-cp -RT /home/custom_files/ /home/${user}/cs2/game/csgo/
+cp -R /home/cs2-modded-server/custom_files/* /home/${user}/cs2/game/csgo/
 
 chown -R ${user}:${user} /home/${user}
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 60Gi #Reccomended Minimum
+      storage: 100Gi #Reccomended Minimum
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -27,6 +27,7 @@ spec:
         app: cs2-modded-server
     spec:
       securityContext:
+        runAsUser: 1000
         fsGroup: 1000
       containers:
         - name: cs2-modded-server
@@ -34,25 +35,31 @@ spec:
           ports:
             - containerPort: 27015
               protocol: TCP
+              name: tcp-game
             - containerPort: 27015
               protocol: UDP
+              name: udp-game
             - containerPort: 27020
               protocol: TCP
+              name: tcp-sourcetv
             - containerPort: 27020
               protocol: UDP
+              name: udp-sourcetv
           env:
-            - name: STEAM_ACCOUNT
+            - name: STEAM_ACCOUNT #Env Var using a kubernetes secret
               valueFrom:
                 secretKeyRef:
                   name: cs2-secret
                   key: STEAM_ACCOUNT
-            - name: API_KEY
+            - name: API_KEY #Env Var in cleartext
               value: "test"
+            - name: CUSTOM_FOLDER
+              value: /home/cs2-modded-server/custom_files
           volumeMounts:
             - name: cs2-data
               mountPath: /home/steam/cs2
             - name: custom
-              mountPath: /home/custom_files/
+              mountPath: /home/cs2-modded-server/custom_files/
       volumes:
         - name: cs2-data
           persistentVolumeClaim:


### PR DESCRIPTION
Had some issues with trying to get `custom_files` loaded correctly. It seems that they were being loaded into `/home/custom_files` for some reason. Instead I propose they are loaded into `/home/cs2-modded-server/custom_files`. Everything is working flawlessly on my end now. This should be reviewed and tested. Is anyone running in compose, as well as someone on k8s able to review and validate changes?

Also updated the recommended minimum as 60gb PV got filled on install and had to jump through hoops to fix it.