### PR TITLE
Add Windows Steam requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Your service will receive an external IP and can be found with `kubectl get svc 
 
 ## Running on Windows
 
-Make sure you have **60GB free space**.
+Make sure you have **60GB free space** and **Steam installed** (you don't need to be logged in, just have Steam installed and updated).
 
 If you have git installed; it is recommended to use git and clone the repo `git clone https://github.com/kus/cs2-modded-server.git` and run your server from inside of it. This way you can simply `git pull` updates (or run `update.bat`). Alternatively you can [Download this repo](https://github.com/kus/cs2-modded-server/archive/master.zip) and extract it to where you want your server (i.e. `C:\Server\cs2-modded-server`) but you will manually have to handle updates.
 


### PR DESCRIPTION
## Problem
On a fresh Windows installation, CS2 dedicated server crashes on startup with:

> Failed to initialize Steamworks SDK for gameserver. Could not determine Steam client install directory.

<img width="852" height="137" alt="image" src="https://github.com/user-attachments/assets/64bb6f90-6109-4d7b-87de-38aa89e5096e" />

(This actually happens directly after CounterStrikeSharp throws a heap of errors and its not immediately obvious that Steamworks is the issue as the window closes immediately after the error).

## Solution
Add a note to readme for Windows users telling them to install Steam and let it update (doesn't need to be logged in).

## Testing
Verified on fresh Windows 11 installation that installing Steam resolves the crash and no other libraries were required.